### PR TITLE
update the icon when machine resumes from sleep state

### DIFF
--- a/WeekNumber/NotificationAreaIcon.cs
+++ b/WeekNumber/NotificationAreaIcon.cs
@@ -106,6 +106,8 @@ public sealed class NotificationAreaIcon : IDisposable
             ContextMenuStrip = _contextMenu
         };
 
+        StartupManager.UpdateRegistryKey();
+
         _notifyIcon.MouseClick += NotifyIcon_LeftMouseClick;
         SystemEvents.PowerModeChanged += OnPowerModeChanged;
         Application.ApplicationExit += OnApplicationExit;

--- a/WeekNumber/NotificationAreaIcon.cs
+++ b/WeekNumber/NotificationAreaIcon.cs
@@ -1,5 +1,6 @@
 ﻿using System.Drawing.Text;
 using System.Globalization;
+using Microsoft.Win32;
 using WeekNumber.Helpers;
 
 namespace WeekNumber;
@@ -106,6 +107,8 @@ public sealed class NotificationAreaIcon : IDisposable
         };
 
         _notifyIcon.MouseClick += NotifyIcon_LeftMouseClick;
+        SystemEvents.PowerModeChanged += OnPowerModeChanged;
+        Application.ApplicationExit += OnApplicationExit;
     }
 
     private void NotifyIcon_LeftMouseClick(object? sender, MouseEventArgs e)
@@ -128,6 +131,25 @@ public sealed class NotificationAreaIcon : IDisposable
         var menuItem = (ToolStripMenuItem)sender!;
         menuItem.Checked = !menuItem.Checked;
         StartupManager.SetStartup(menuItem.Checked);
+    }
+
+    private void OnPowerModeChanged(object? sender, PowerModeChangedEventArgs e)
+    {
+        if (e.Mode != PowerModes.Resume)
+        {
+            return;
+        }
+
+        _weekNumber.UpdateNumber();
+        UpdateIcon();
+        UpdateText();
+    }
+    
+    private void OnApplicationExit(object? sender, EventArgs e)
+    {
+        SystemEvents.PowerModeChanged -= OnPowerModeChanged;
+        Application.ApplicationExit -= OnApplicationExit;
+        _notifyIcon.MouseClick -= NotifyIcon_LeftMouseClick;
     }
 
     private static void MenuExit_Click(object? sender, EventArgs e)

--- a/WeekNumber/StartupManager.cs
+++ b/WeekNumber/StartupManager.cs
@@ -24,6 +24,32 @@ public static class StartupManager
         key.SetValue(AppName, exePath);
     }
 
+    public static void UpdateRegistryKey()
+    {
+        using var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(RegistryKey, true);
+
+        if (key == null)
+        {
+            return;
+        }
+
+        var registryExePath = key.GetValue(AppName) as string;
+
+        if (string.IsNullOrEmpty(registryExePath))
+        {
+            return;
+        }
+
+        var exePath = Application.ExecutablePath;
+
+        if (string.Equals(registryExePath, exePath, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        key.SetValue(AppName, exePath);
+    }
+
     public static bool IsStartupEnabled()
     {
         using var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(RegistryKey);


### PR DESCRIPTION
also update the registrykey if it does not match the current executable path (the user does not need to reapply [Run at startup] everytime they install an update)