### PR TITLE
bugfixes

### DIFF
--- a/WeekNumber/Forms/AboutForm.cs
+++ b/WeekNumber/Forms/AboutForm.cs
@@ -1,9 +1,30 @@
+using System.Drawing.Drawing2D;
 using WeekNumber.Helpers;
 
 namespace WeekNumber.Forms;
 
 public class AboutForm : Form
 {
+    private static AboutForm? _instance;
+
+    public static void ShowInstance()
+    {
+        if (_instance != null)
+        {
+            _instance.BringToFront();
+            _instance.Focus();
+            return;
+        }
+        _instance = new AboutForm();
+        _instance.Show();
+    }
+
+    protected override void OnFormClosed(FormClosedEventArgs e)
+    {
+        base.OnFormClosed(e);
+        _instance = null;
+    }
+
     protected override void OnLoad(EventArgs e)
     {
         base.OnLoad(e);
@@ -12,97 +33,159 @@ public class AboutForm : Form
 
     private void InitializeForm()
     {
-        Text = $"WeekNumber {VersionHelper.GetAppVersion()}";
-        Size = new Size(FormWidth, FormHeight);
+        AutoScaleMode = AutoScaleMode.None;
+        Text = "WeekNumber";
         FormBorderStyle = FormBorderStyle.FixedDialog;
-        StartPosition = FormStartPosition.CenterScreen;
+        StartPosition = FormStartPosition.Manual;
         MaximizeBox = false;
         MinimizeBox = false;
         ShowIcon = false;
         ShowInTaskbar = false;
-        MinimumSize = new Size(FormWidth, MinimumSize.Height);
+        BackColor = Color.White;
+        DoubleBuffered = true;
 
-        var table = CreateLayoutTable();
-        Controls.Add(table);
+        float scale = DeviceDpi / 96f;
+
+        int clientW = Scale(380, scale);
+        int clientH = Scale(175, scale);
+        ClientSize = new Size(clientW, clientH);
+
+        var screen = Screen.FromPoint(Cursor.Position);
+        Location = new Point(
+            screen.WorkingArea.Left + (screen.WorkingArea.Width  - Width)  / 2,
+            screen.WorkingArea.Top  + (screen.WorkingArea.Height - Height) / 2
+        );
+
+        BuildUI(scale, clientW, clientH);
     }
 
-    private TableLayoutPanel CreateLayoutTable()
+    private void BuildUI(float scale, int clientW, int clientH)
     {
-        var table = new TableLayoutPanel
-        {
-            Dock = DockStyle.Fill,
-            Padding = new Padding(TablePadding),
-            ColumnCount = 2,
-            RowCount = 1
-        };
-        table.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, IconSize));
-        table.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-        table.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        int pad             = Scale(28, scale);
+        int iconSize        = Scale(80, scale);
+        int gap             = Scale(20, scale);
+        int btnH            = Scale(36, scale);
+        int btnMarginBottom = Scale(16, scale);
 
-        table.Controls.Add(CreatePictureBox(), 0, 0);
-        var link = CreateGitHubLinkLabel();
-        table.Controls.Add(link, 1, 0);
-        link.Dock = DockStyle.Fill;
-        return table;
-    }
-
-    private PictureBox CreatePictureBox()
-    {
         var iconPath = Path.Combine(AppContext.BaseDirectory, "Resources", "AppIcon.ico");
-        Image bodyImage = File.Exists(iconPath)
-            ? LoadIconImage(iconPath)
+        Image iconImage = File.Exists(iconPath)
+            ? LoadIconImage(iconPath, iconSize)
             : SystemIcons.Application.ToBitmap();
 
-        return new PictureBox
+        var picture = new PictureBox
         {
-            Size = new Size(IconSize, IconSize),
-            SizeMode = PictureBoxSizeMode.Zoom,
-            Image = bodyImage,
-            Margin = new Padding(PictureMarginLeft, PictureMarginTop, PictureMarginRight, PictureMarginBottom)
+            Size      = new Size(iconSize, iconSize),
+            SizeMode  = PictureBoxSizeMode.Zoom,
+            Image     = iconImage,
+            BackColor = Color.Transparent,
+            Location  = new Point(pad, (clientH - btnH - btnMarginBottom - iconSize) / 2)
         };
+        Controls.Add(picture);
+
+        int textX    = pad + iconSize + gap;
+        int textTopY = picture.Location.Y;
+
+        var nameFont    = new Font("Segoe UI", ScaleFont(15f, scale), FontStyle.Bold);
+        var versionFont = new Font("Segoe UI", ScaleFont(9f,  scale), FontStyle.Regular);
+
+        var nameLabel = new Label
+        {
+            Text      = "WeekNumber",
+            Font      = nameFont,
+            ForeColor = Color.FromArgb(20, 20, 20),
+            BackColor = Color.Transparent,
+            AutoSize  = true,
+            Location  = new Point(textX, textTopY)
+        };
+        Controls.Add(nameLabel);
+
+        var versionLabel = new Label
+        {
+            Text      = $"Version {VersionHelper.GetAppVersion()}",
+            Font      = versionFont,
+            ForeColor = Color.FromArgb(130, 130, 140),
+            BackColor = Color.Transparent,
+            AutoSize  = true,
+            Location  = new Point(textX + Scale(2, scale), textTopY + nameLabel.PreferredHeight + Scale(4, scale))
+        };
+        Controls.Add(versionLabel);
+
+        var githubBtn = new FlatButton
+        {
+            Text     = "View on GitHub  ↗",
+            Size     = new Size(clientW - pad * 2, btnH),
+            Location = new Point(pad, clientH - btnH - btnMarginBottom),
+            Font     = new Font("Segoe UI", ScaleFont(9f, scale), FontStyle.Regular),
+            Cursor   = Cursors.Hand
+        };
+        githubBtn.Click += (_, _) =>
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName        = GitHubUrl,
+                UseShellExecute = true
+            });
+        Controls.Add(githubBtn);
     }
 
-    private static Bitmap LoadIconImage(string iconPath)
+    private static Bitmap LoadIconImage(string iconPath, int size)
     {
-        using var icon = new Icon(iconPath, new Size(IconSize, IconSize));
+        using var icon = new Icon(iconPath, new Size(size, size));
         return icon.ToBitmap();
     }
 
-    private static LinkLabel CreateGitHubLinkLabel()
+    private static int   Scale(int value, float scale)    => (int)Math.Round(value * scale);
+    private static float ScaleFont(float pt, float scale) => pt * scale;
+
+    private const string GitHubUrl = "https://github.com/anthony0tran/week-number";
+}
+
+internal class FlatButton : Control
+{
+    private bool _hovered;
+    private bool _pressed;
+
+    public FlatButton()
     {
-        var baseSize = (SystemFonts.MessageBoxFont ?? SystemFonts.DefaultFont).Size;
-        var link = new LinkLabel
-        {
-            Text = "Check out our GitHub page!",
-            AutoSize = true,
-            Tag = GitHubUrl,
-            Font = new Font((SystemFonts.MessageBoxFont ?? SystemFonts.DefaultFont).FontFamily, baseSize + LinkFontSizeDelta, FontStyle.Bold),
-            Margin = new Padding(LinkMarginLeft, LinkMarginTop, LinkMarginRight, LinkMarginBottom),
-            LinkBehavior = LinkBehavior.HoverUnderline,
-            TextAlign = ContentAlignment.MiddleLeft,
-            AutoEllipsis = true
-        };
-        link.LinkClicked += (_, _) =>
-            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-            {
-                FileName = (string)link.Tag!,
-                UseShellExecute = true
-            });
-        return link;
+        SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint, true);
+        DoubleBuffered = true;
     }
 
-    private const int FormWidth = 360;
-    private const int FormHeight = 220;
-    private const int IconSize = 128;
-    private const int TablePadding = 12;
-    private const int PictureMarginLeft = 12;
-    private const int PictureMarginTop = 12;
-    private const int PictureMarginRight = 16;
-    private const int PictureMarginBottom = 12;
-    private const int LinkMarginLeft = 0;
-    private const int LinkMarginTop = 12;
-    private const int LinkMarginRight = 12;
-    private const int LinkMarginBottom = 12;
-    private const float LinkFontSizeDelta = 4f;
-    private const string GitHubUrl = "https://github.com/anthony0tran/week-number";
+    protected override void OnMouseEnter(EventArgs e) { _hovered = true;  Invalidate(); base.OnMouseEnter(e); }
+    protected override void OnMouseLeave(EventArgs e) { _hovered = false; Invalidate(); base.OnMouseLeave(e); }
+    protected override void OnMouseDown(MouseEventArgs e) { _pressed = true;  Invalidate(); base.OnMouseDown(e); }
+    protected override void OnMouseUp(MouseEventArgs e)   { _pressed = false; Invalidate(); base.OnMouseUp(e); }
+
+    protected override void OnPaint(PaintEventArgs e)
+    {
+        var g = e.Graphics;
+        g.SmoothingMode = SmoothingMode.AntiAlias;
+
+        var rect = new Rectangle(0, 0, Width - 1, Height - 1);
+
+        Color fill = _pressed ? Color.FromArgb(225, 225, 230)
+                   : _hovered ? Color.FromArgb(240, 240, 245)
+                   :            Color.FromArgb(246, 246, 248);
+
+        using var path = RoundedRect(rect, 8);
+        using var fillBrush = new SolidBrush(fill);
+        g.FillPath(fillBrush, path);
+
+        using var borderPen = new Pen(Color.FromArgb(210, 210, 218), 1f);
+        g.DrawPath(borderPen, path);
+
+        using var sf = new StringFormat { Alignment = StringAlignment.Center, LineAlignment = StringAlignment.Center };
+        using var textBrush = new SolidBrush(Color.FromArgb(30, 30, 35));
+        g.DrawString(Text, Font, textBrush, (RectangleF)rect, sf);
+    }
+
+    private static GraphicsPath RoundedRect(Rectangle b, int r)
+    {
+        var p = new GraphicsPath();
+        p.AddArc(b.X,             b.Y,              r * 2, r * 2, 180, 90);
+        p.AddArc(b.Right - r * 2, b.Y,              r * 2, r * 2, 270, 90);
+        p.AddArc(b.Right - r * 2, b.Bottom - r * 2, r * 2, r * 2, 0,   90);
+        p.AddArc(b.X,             b.Bottom - r * 2, r * 2, r * 2, 90,  90);
+        p.CloseFigure();
+        return p;
+    }
 }

--- a/WeekNumber/Forms/CalendarControl.cs
+++ b/WeekNumber/Forms/CalendarControl.cs
@@ -1,4 +1,3 @@
-
 using System.ComponentModel;
 using System.Globalization;
 using System.Drawing.Drawing2D;
@@ -7,50 +6,58 @@ namespace WeekNumber.Forms;
 
 internal sealed class CalendarControl : Control
 {
-    // Fixed rows per month grid.
     private const int FixedWeeksPerMonth = 6;
 
-    // Layout metrics.
-    private int _headerHeight = 28;
-    private int _headerVertPadding = 8;
-    private int _weekRowHeight = 20;
-    private int _cellHeight = 24;
-    private int _cellWidth = 34;
-    private int _monthGap = 14;
-    private int _weekColumnWidth = 36;
-    private int _headerSidePadding = 26;
-    private int _footerHeight = 30;
-    private int _footerSeparatorGap = 6;
-    private int _gridBottomGap = 4;
-    private int _padLeft = 8;
-    private int _padTop = 8;
-    private int _padRight = 14;
-    private int _padBottom = 10;
+    // ── Fixed pixel metrics at 96 DPI ────────────────────────────────────────
+    private const int B_HeaderVertPadding   = 8;
+    private const int B_WeekRowHeight       = 20;
+    private const int B_CellHeight          = 24;
+    private const int B_CellWidth           = 34;
+    private const int B_MonthGap            = 14;
+    private const int B_WeekColumnWidth     = 36;
+    private const int B_HeaderSidePadding   = 26;
+    private const int B_FooterHeight        = 30;
+    private const int B_FooterSeparatorGap  = 6;
+    private const int B_GridBottomGap       = 4;
+    private const int B_PadLeft             = 8;
+    private const int B_PadTop              = 8;
+    private const int B_PadRight            = 14;
+    private const int B_PadBottom           = 10;
+    private const int B_TodayCircleDiameter = 22;
+    private const int B_FooterBoxSize       = 16;
 
-    // Theme colors.
-    private static readonly Color HeaderBlueColor = Color.FromArgb(0x2B, 0x74, 0xE6);
-    private static readonly Color WeekNumberColor = Color.FromArgb(0x7A, 0x58, 0x58);
-    private static readonly Color TrailingDayColor = Color.FromArgb(0xCF, 0xCF, 0xD3);
-    private static readonly Color TodayCircleColor = Color.FromArgb(0xB3, 0x1B, 0x1B);
-    private static readonly Color DividerColor = Color.FromArgb(0xE6, 0xE6, 0xE6);
-    private static readonly Color WeekHighlightFillColor = Color.FromArgb(0xE0, 0xEC, 0xFF);
+    // ── Live metrics — reset every paint ─────────────────────────────────────
+    private int _headerHeight;
+    private int _headerVertPadding;
+    private int _weekRowHeight;
+    private int _cellHeight;
+    private int _cellWidth;
+    private int _monthGap;
+    private int _weekColumnWidth;
+    private int _headerSidePadding;
+    private int _footerHeight;
+    private int _footerSeparatorGap;
+    private int _gridBottomGap;
+    private int _padLeft, _padTop, _padRight, _padBottom;
+    private int _todayCircleDiameter;
+    private int _footerBoxSize;
+
+    // ── Theme colors ─────────────────────────────────────────────────────────
+    private static readonly Color HeaderBlueColor          = Color.FromArgb(0x2B, 0x74, 0xE6);
+    private static readonly Color WeekNumberColor          = Color.FromArgb(0x7A, 0x58, 0x58);
+    private static readonly Color TrailingDayColor         = Color.FromArgb(0xB8, 0xB8, 0xBC);
+    private static readonly Color TodayCircleColor         = Color.FromArgb(0xB3, 0x1B, 0x1B);
+    private static readonly Color DividerColor             = Color.FromArgb(0xE6, 0xE6, 0xE6);
+    private static readonly Color WeekHighlightFillColor   = Color.FromArgb(0xE0, 0xEC, 0xFF);
     private static readonly Color WeekHighlightBorderColor = Color.FromArgb(0xAD, 0xCA, 0xFF);
 
-    // Title vertical position ratio inside header band (0..1).
     private readonly float _headerTitleCenterRatio = 0.28f;
 
-    // Today circle visuals.
-    private const int TodayCircleDiameter = 26;
-    private const float TodayCircleStroke = 1.8f;
-
-    // Public configuration surface.
+    // ── Public configuration ─────────────────────────────────────────────────
     [DefaultValue(typeof(Size), "2, 1")] public Size CalendarDimensions { get; init; } = new(2, 1);
-
-    [DefaultValue(true)] public bool ShowWeekNumbers { get; init; } = true;
-
-    [DefaultValue(true)] public bool ShowToday { get; init; } = true;
-
-    [DefaultValue(true)] public bool ShowTodayCircle { get; init; } = true;
+    [DefaultValue(true)]  public bool ShowWeekNumbers  { get; init; } = true;
+    [DefaultValue(true)]  public bool ShowToday        { get; init; } = true;
+    [DefaultValue(true)]  public bool ShowTodayCircle  { get; init; } = true;
 
     [DefaultValue(typeof(Color), "Black")]
     public Color HeaderForeground { get; init; } = Color.FromArgb(0x1F, 0x1F, 0x1F);
@@ -61,49 +68,43 @@ internal sealed class CalendarControl : Control
     [DefaultValue(typeof(Color), "0, 100, 210")]
     public Color Accent { get; init; } = Color.FromArgb(0x1E, 0x6B, 0xD6);
 
-    // Current display month (first of month).
     [Browsable(false), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public DateTime DisplayMonth { get; private set; } = new DateTime(DateTime.Today.Year, DateTime.Today.Month, 1);
 
-    // Cached hit rectangles.
+    // ── Hit rects ────────────────────────────────────────────────────────────
     private Rectangle _prevChevronRect;
     private Rectangle _nextChevronRect;
     private Rectangle _todayBoxRect;
     private Rectangle _footerRect;
 
-    // Week highlight anchor (ISO week start) and owning month (first of month).
     private DateTime? _highlightWeekStart;
     private DateTime? _highlightWeekMonth;
 
-    // Culture used for names/formatting.
     private readonly CultureInfo _culture;
 
-    // Sets ISO culture defaults and paints with double-buffering.
     public CalendarControl()
     {
         _culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
         _culture.DateTimeFormat.CalendarWeekRule = CalendarWeekRule.FirstFourDayWeek;
-        _culture.DateTimeFormat.FirstDayOfWeek = DayOfWeek.Monday;
+        _culture.DateTimeFormat.FirstDayOfWeek   = DayOfWeek.Monday;
 
         SetStyle(
-            ControlStyles.AllPaintingInWmPaint |
+            ControlStyles.AllPaintingInWmPaint  |
             ControlStyles.OptimizedDoubleBuffer |
-            ControlStyles.ResizeRedraw |
+            ControlStyles.ResizeRedraw          |
             ControlStyles.UserPaint, true);
 
         TabStop = false;
-        Cursor = Cursors.Default;
+        Cursor  = Cursors.Default;
 
         MouseWheel += (_, e) =>
         {
-            // Scroll up -> previous; scroll down -> next.
             DisplayMonth = DisplayMonth.AddMonths(e.Delta > 0 ? -1 : 1);
             Invalidate();
         };
     }
 
-    // Updates the highlighted ISO week and repaints (programmatic use).
-    // Owning month is required to avoid duplicating highlight across adjacent months.
+    // ── Public API ───────────────────────────────────────────────────────────
     public void HighlightIsoWeek(DateTime anyDate, DateTime owningMonthFirstOfMonth)
     {
         _highlightWeekStart = StartOfIsoWeek(anyDate);
@@ -111,8 +112,6 @@ internal sealed class CalendarControl : Control
         Invalidate();
     }
 
-    // Backwards-compatible overload: defaults ownership to the calendar month currently showing 'anyDate'.
-    // If the control shows multiple months including 'anyDate', the month matching 'anyDate' gets ownership.
     public void HighlightIsoWeek(DateTime anyDate)
     {
         _highlightWeekStart = StartOfIsoWeek(anyDate);
@@ -120,54 +119,18 @@ internal sealed class CalendarControl : Control
         Invalidate();
     }
 
-    // Scales all metrics with DPI changes.
-    protected override void ScaleControl(SizeF factor, BoundsSpecified specified)
-    {
-        base.ScaleControl(factor, specified);
-
-        _headerHeight = (int)Math.Round(_headerHeight * factor.Height);
-        _headerVertPadding = (int)Math.Round(_headerVertPadding * factor.Height);
-        _weekRowHeight = (int)Math.Round(_weekRowHeight * factor.Height);
-        _cellHeight = (int)Math.Round(_cellHeight * factor.Height);
-        _cellWidth = (int)Math.Round(_cellWidth * factor.Width);
-        _monthGap = (int)Math.Round(_monthGap * factor.Width);
-        _weekColumnWidth = (int)Math.Round(_weekColumnWidth * factor.Width);
-        _headerSidePadding = (int)Math.Round(_headerSidePadding * factor.Width);
-        _footerHeight = (int)Math.Round(_footerHeight * factor.Height);
-        _footerSeparatorGap = (int)Math.Round(_footerSeparatorGap * factor.Height);
-        _gridBottomGap = (int)Math.Round(_gridBottomGap * factor.Height);
-        _padLeft = (int)Math.Round(_padLeft * factor.Width);
-        _padTop = (int)Math.Round(_padTop * factor.Height);
-        _padRight = (int)Math.Round(_padRight * factor.Width);
-        _padBottom = (int)Math.Round(_padBottom * factor.Height);
-    }
-
-    // Returns the preferred control size from current font/culture and layout metrics.
     public override Size GetPreferredSize(Size proposedSize)
     {
         using var g = CreateGraphics();
         ComputeMetrics(g);
-
-        int across = CalendarDimensions.Width;
-        int down = CalendarDimensions.Height;
-
-        int weekColWidth = ShowWeekNumbers ? _weekColumnWidth : 0;
-        int monthWidth = weekColWidth + (_cellWidth * 7);
-        int monthHeightFixed = _headerHeight + _weekRowHeight + (_cellHeight * FixedWeeksPerMonth);
-
-        int gridHeightAll = down * monthHeightFixed + (down - 1) * _monthGap;
-        int totalWidth = _padLeft + _padRight + across * monthWidth + (across - 1) * _monthGap;
-        int totalHeight = _padTop + gridHeightAll + _gridBottomGap + 1 + _footerSeparatorGap + _footerHeight +
-                          _padBottom;
-
-        return new Size(totalWidth, totalHeight);
+        return ComputeTotalSize();
     }
 
-    // Paints the full calendar surface and aligns chevrons to the title center.
+    // ── Paint ─────────────────────────────────────────────────────────────────
     protected override void OnPaint(PaintEventArgs e)
     {
         var g = e.Graphics;
-        g.SmoothingMode = SmoothingMode.AntiAlias;
+        g.SmoothingMode     = SmoothingMode.AntiAlias;
         g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
 
         ComputeMetrics(g);
@@ -175,343 +138,377 @@ internal sealed class CalendarControl : Control
         using (var bg = new SolidBrush(BackColor))
             g.FillRectangle(bg, ClientRectangle);
 
-        using var headerFont = new Font(Font.FontFamily, Font.Size + 0.5f, FontStyle.Regular);
+        PaintHeader(g);
+        PaintGrid(g);
+        PaintFooter(g);
+    }
 
-        int headerTop = _padTop;
-        int titleCenterY = headerTop + (int)Math.Round(_headerHeight * _headerTitleCenterRatio);
+    // ── Header — month titles + chevrons (never slides) ──────────────────────
+    private void PaintHeader(Graphics g)
+    {
+        using var headerFont = new Font(Font.FontFamily, Font.Size + 0.5f, FontStyle.Bold);
 
-        // Chevron rectangles vertically centered to month title center.
-        Size chevronSize = new Size(_headerSidePadding - 8, _headerHeight - 10);
-        int chevronHalfH = chevronSize.Height / 2;
+        int titleCenterY = _padTop + (int)Math.Round(_headerHeight * _headerTitleCenterRatio);
+        int chevronHalfH = (_headerHeight - 10) / 2;
+        int chevronW     = _headerSidePadding - 8;
 
         _prevChevronRect = new Rectangle(
             _padLeft + 1,
             titleCenterY - chevronHalfH,
-            chevronSize.Width,
-            chevronSize.Height);
+            chevronW,
+            chevronHalfH * 2);
 
         _nextChevronRect = new Rectangle(
             Width - _padRight - _headerSidePadding + 7,
             titleCenterY - chevronHalfH,
-            chevronSize.Width,
-            chevronSize.Height);
+            chevronW,
+            chevronHalfH * 2);
 
         DrawChevron(g, _prevChevronRect, left: true);
         DrawChevron(g, _nextChevronRect, left: false);
 
+        // Draw each month's title inside the fixed header band.
         int across = CalendarDimensions.Width;
-        int down = CalendarDimensions.Height;
+        int down   = CalendarDimensions.Height;
 
         int weekColWidth = ShowWeekNumbers ? _weekColumnWidth : 0;
-        int monthWidth = weekColWidth + (_cellWidth * 7);
-        int monthHeightFixed = _headerHeight + _weekRowHeight + (_cellHeight * FixedWeeksPerMonth);
+        int monthWidth   = weekColWidth + _cellWidth * 7;
+        int mhFixed      = _headerHeight + _weekRowHeight + _cellHeight * FixedWeeksPerMonth;
 
         var monthCursor = DisplayMonth;
-        int yCursor = _padTop;
+        int yCursor     = _padTop;
+        var dtf         = _culture.DateTimeFormat;
 
         for (int r = 0; r < down; r++)
         {
             int xCursor = _padLeft;
-
             for (int c = 0; c < across; c++)
             {
-                var bounds = new Rectangle(xCursor, yCursor, monthWidth, monthHeightFixed);
-                DrawMonth(g, bounds, monthCursor, headerFont);
+                string title     = $"{dtf.GetMonthName(monthCursor.Month)} {monthCursor.Year}";
+                var    titleSize = TextRenderer.MeasureText(g, title, headerFont,
+                    new Size(int.MaxValue, int.MaxValue),
+                    TextFormatFlags.NoPadding | TextFormatFlags.SingleLine);
+
+                int titleCY  = yCursor + (int)Math.Round(_headerHeight * _headerTitleCenterRatio);
+                int titleTop = titleCY - titleSize.Height / 2;
+
+                TextRenderer.DrawText(g, title, headerFont,
+                    new Rectangle(xCursor, titleTop, monthWidth, titleSize.Height),
+                    HeaderForeground,
+                    TextFormatFlags.HorizontalCenter | TextFormatFlags.Top |
+                    TextFormatFlags.SingleLine       | TextFormatFlags.NoPadding);
+
+                monthCursor = monthCursor.AddMonths(1);
+                xCursor += monthWidth + (c < across - 1 ? _monthGap : 0);
+            }
+            yCursor += mhFixed + (r < down - 1 ? _monthGap : 0);
+        }
+    }
+
+    // ── Grid — day-name rows + date cells + between-month dividers (slides) ──
+    private void PaintGrid(Graphics g)
+    {
+        int across  = CalendarDimensions.Width;
+        int down    = CalendarDimensions.Height;
+
+        int weekColWidth = ShowWeekNumbers ? _weekColumnWidth : 0;
+        int monthWidth   = weekColWidth + _cellWidth * 7;
+        int mhFixed      = _headerHeight + _weekRowHeight + _cellHeight * FixedWeeksPerMonth;
+
+        var monthCursor = DisplayMonth;
+        int yCursor     = _padTop;
+
+        for (int r = 0; r < down; r++)
+        {
+            int xCursor = _padLeft;
+            for (int c = 0; c < across; c++)
+            {
+                var bounds = new Rectangle(xCursor, yCursor, monthWidth, mhFixed);
+                DrawMonthGrid(g, bounds, monthCursor);
                 monthCursor = monthCursor.AddMonths(1);
 
                 if (c < across - 1)
                 {
-                    int dividerX = bounds.Right + _monthGap / 2;
-                    using var p = new Pen(DividerColor, 1f);
-                    g.DrawLine(p, dividerX, bounds.Top + _headerHeight, dividerX, bounds.Bottom);
+                    int divX = bounds.Right + _monthGap / 2;
+                    using var dp = new Pen(DividerColor, 1f);
+                    // Divider starts below the header band.
+                    g.DrawLine(dp, divX, bounds.Top + _headerHeight, divX, bounds.Bottom);
                 }
 
                 xCursor += monthWidth + (c < across - 1 ? _monthGap : 0);
             }
-
-            yCursor += monthHeightFixed + (r < down - 1 ? _monthGap : 0);
+            yCursor += mhFixed + (r < down - 1 ? _monthGap : 0);
         }
+    }
 
-        int sepY = _padTop + (down * monthHeightFixed) + ((down - 1) * _monthGap) + _gridBottomGap;
-        using (var p = new Pen(DividerColor, 1f))
-            g.DrawLine(p, _padLeft, sepY, Width - _padRight, sepY);
+    // ── Footer — separator line + today box + today text (never slides) ──────
+    private void PaintFooter(Graphics g)
+    {
+        int down    = CalendarDimensions.Height;
+        int mhFixed = _headerHeight + _weekRowHeight + _cellHeight * FixedWeeksPerMonth;
+        int sepY    = _padTop + down * mhFixed + (down - 1) * _monthGap + _gridBottomGap;
 
-        var footerRect = new Rectangle(
+        using (var sp = new Pen(DividerColor, 1f))
+            g.DrawLine(sp, _padLeft, sepY, Width - _padRight, sepY);
+
+        _footerRect = new Rectangle(
             _padLeft,
             sepY + _footerSeparatorGap,
             Width - (_padLeft + _padRight),
             _footerHeight);
 
-        const int boxSize = 16;
-        int boxY = footerRect.Y + (footerRect.Height - boxSize) / 2;
-        _todayBoxRect = new Rectangle(footerRect.X, boxY, boxSize, boxSize);
-        _footerRect = footerRect;
+        int boxY = _footerRect.Y + (_footerRect.Height - _footerBoxSize) / 2;
+        _todayBoxRect = new Rectangle(_footerRect.X, boxY, _footerBoxSize, _footerBoxSize);
 
-        using (var boxPen = new Pen(Accent, 2))
+        // Fill background behind footer to cover any grid bleed.
+        using (var bg = new SolidBrush(BackColor))
+            g.FillRectangle(bg, _footerRect);
+
+        using (var boxPen = new Pen(Accent, 2f))
             g.DrawRectangle(boxPen, _todayBoxRect);
-
-        var dtf = _culture.DateTimeFormat;
-        var todayTextRect = new Rectangle(_todayBoxRect.Right + 8, footerRect.Y,
-            footerRect.Width - (_todayBoxRect.Width + 8), footerRect.Height);
 
         TextRenderer.DrawText(g,
             $"Today: {DateTime.Today.ToString("dd-MM-yyyy", _culture)}",
             Font,
-            todayTextRect,
+            new Rectangle(_todayBoxRect.Right + 8, _footerRect.Y,
+                          _footerRect.Width - (_footerBoxSize + 8), _footerRect.Height),
             SecondaryForeground,
             TextFormatFlags.VerticalCenter |
-            TextFormatFlags.Left |
-            TextFormatFlags.SingleLine |
+            TextFormatFlags.Left           |
+            TextFormatFlags.SingleLine     |
             TextFormatFlags.NoPadding);
     }
 
-    // Draws a single month header, weekday headers, grid, week numbers, highlights, and today circle.
-    private void DrawMonth(Graphics g, Rectangle bounds, DateTime month, Font headerFont)
+    // ── Month grid — day-name row + date cells for one month ─────────────────
+    private void DrawMonthGrid(Graphics g, Rectangle bounds, DateTime month)
     {
-        var dtf = _culture.DateTimeFormat;
-        List<Rectangle> todayCircles = new();
-        
-        string title = $"{dtf.GetMonthName(month.Month)} {month.Year}";
-        var titleSize = TextRenderer.MeasureText(g, title, headerFont, new Size(int.MaxValue, int.MaxValue),
-            TextFormatFlags.NoPadding | TextFormatFlags.SingleLine);
-
-        int titleCenterY = bounds.Y + (int)Math.Round(_headerHeight * _headerTitleCenterRatio);
-        int titleTop = titleCenterY - titleSize.Height / 2;
-
-        var headerTitleRect = new Rectangle(bounds.X, titleTop, bounds.Width, titleSize.Height);
-        TextRenderer.DrawText(g, title, headerFont, headerTitleRect, HeaderForeground,
-            TextFormatFlags.HorizontalCenter |
-            TextFormatFlags.Top |
-            TextFormatFlags.SingleLine |
-            TextFormatFlags.NoPadding);
+        var dtf          = _culture.DateTimeFormat;
+        var todayCircles = new List<Rectangle>();
 
         int weekColWidth = ShowWeekNumbers ? _weekColumnWidth : 0;
-        var namesRect = new Rectangle(bounds.X, bounds.Y + _headerHeight, bounds.Width, _weekRowHeight);
+        int colX         = bounds.X;
+        int namesY       = bounds.Y + _headerHeight;
 
-        int colX = bounds.X;
-
+        // Day-name header row (CW + Mon..Sun).
         if (ShowWeekNumbers)
         {
-            var wkRect = new Rectangle(colX, namesRect.Y, weekColWidth, namesRect.Height);
-            TextRenderer.DrawText(g, "CW", Font, wkRect, SecondaryForeground,
-                TextFormatFlags.HorizontalCenter |
-                TextFormatFlags.VerticalCenter |
-                TextFormatFlags.SingleLine |
-                TextFormatFlags.NoPadding);
+            TextRenderer.DrawText(g, "CW", Font,
+                new Rectangle(colX, namesY, weekColWidth, _weekRowHeight),
+                Color.FromArgb(0xB0, 0xB0, 0xB0),
+                TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter |
+                TextFormatFlags.SingleLine       | TextFormatFlags.NoPadding);
             colX += weekColWidth;
         }
 
         for (int d = 0; d < 7; d++)
         {
             string name = dtf.AbbreviatedDayNames[((int)dtf.FirstDayOfWeek + d) % 7];
-            var rect = new Rectangle(colX, namesRect.Y, _cellWidth, namesRect.Height);
-            TextRenderer.DrawText(g, name, Font, rect, HeaderBlueColor,
-                TextFormatFlags.HorizontalCenter |
-                TextFormatFlags.VerticalCenter |
-                TextFormatFlags.SingleLine |
-                TextFormatFlags.NoPadding);
+            TextRenderer.DrawText(g, name, Font,
+                new Rectangle(colX, namesY, _cellWidth, _weekRowHeight),
+                HeaderBlueColor,
+                TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter |
+                TextFormatFlags.SingleLine       | TextFormatFlags.NoPadding);
             colX += _cellWidth;
         }
 
+        // Date grid.
         DateTime firstOfMonth = new DateTime(month.Year, month.Month, 1);
-        int offset = (((int)firstOfMonth.DayOfWeek - (int)dtf.FirstDayOfWeek) + 7) % 7;
-        DateTime gridStart = firstOfMonth.AddDays(-offset);
+        int      offset       = (((int)firstOfMonth.DayOfWeek - (int)dtf.FirstDayOfWeek) + 7) % 7;
+        DateTime gridStart    = firstOfMonth.AddDays(-offset);
 
-        int weekColX = bounds.X;
         int gridXStart = bounds.X + weekColWidth;
-        int gridY = bounds.Y + _headerHeight + _weekRowHeight;
+        int gridY      = bounds.Y + _headerHeight + _weekRowHeight;
 
         for (int row = 0; row < FixedWeeksPerMonth; row++)
         {
             DateTime rowWeekStart = StartOfIsoWeek(gridStart.AddDays(row * 7));
 
-            // Only highlight if both the week start matches AND this month owns the highlight.
             if (_highlightWeekStart.HasValue &&
                 _highlightWeekMonth.HasValue &&
                 rowWeekStart == _highlightWeekStart.Value &&
-                month.Date == _highlightWeekMonth.Value)
+                month.Date   == _highlightWeekMonth.Value)
             {
-                
-                int left = bounds.X + 2;
-                int right = bounds.Right - 2;
-
-
                 var bar = Rectangle.FromLTRB(
-                    left,
-                    gridY,
-                    right,
-                    gridY + _cellHeight);
-
+                    bounds.X + 2, gridY,
+                    bounds.Right - 2, gridY + _cellHeight);
 
                 using var fill = new SolidBrush(WeekHighlightFillColor);
-                using var pen = new Pen(WeekHighlightBorderColor, 1f);
-
+                using var hpen = new Pen(WeekHighlightBorderColor, 1f);
                 g.FillRectangle(fill, bar);
-                g.DrawRectangle(pen, bar.X, bar.Y, bar.Width - 1, bar.Height - 1);
-
-
+                g.DrawRectangle(hpen, bar.X, bar.Y, bar.Width - 1, bar.Height - 1);
             }
 
             if (ShowWeekNumbers)
             {
                 int weekNumber = ISOWeek.GetWeekOfYear(rowWeekStart);
-                var wkRect = new Rectangle(weekColX, gridY, weekColWidth, _cellHeight);
-                TextRenderer.DrawText(g, weekNumber.ToString(), Font, wkRect, WeekNumberColor,
-                    TextFormatFlags.HorizontalCenter |
-                    TextFormatFlags.VerticalCenter |
-                    TextFormatFlags.SingleLine |
-                    TextFormatFlags.NoPadding);
+                TextRenderer.DrawText(g, weekNumber.ToString(), Font,
+                    new Rectangle(bounds.X, gridY, weekColWidth, _cellHeight),
+                    WeekNumberColor,
+                    TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter |
+                    TextFormatFlags.SingleLine       | TextFormatFlags.NoPadding);
             }
 
             int cx = gridXStart;
             for (int col = 0; col < 7; col++)
             {
-                var day = gridStart.AddDays(row * 7 + col);
-                var rect = new Rectangle(cx, gridY, _cellWidth, _cellHeight);
-
+                var  day     = gridStart.AddDays(row * 7 + col);
+                var  rect    = new Rectangle(cx, gridY, _cellWidth, _cellHeight);
                 bool inMonth = day.Month == month.Month;
-                bool isToday = day.Date == DateTime.Today.Date;
+                bool isToday = day.Date  == DateTime.Today.Date;
 
-                var numberColor = inMonth ? HeaderForeground : TrailingDayColor;
-
-                TextRenderer.DrawText(g, day.Day.ToString(), Font, rect, numberColor,
-                    TextFormatFlags.HorizontalCenter |
-                    TextFormatFlags.VerticalCenter |
-                    TextFormatFlags.SingleLine |
-                    TextFormatFlags.NoPadding);
-
-                // Draw "today" circle only if today exists AND belongs to this month.
+                TextRenderer.DrawText(g, day.Day.ToString(), Font, rect,
+                    inMonth ? HeaderForeground : TrailingDayColor,
+                    TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter |
+                    TextFormatFlags.SingleLine       | TextFormatFlags.NoPadding);
 
                 if (ShowToday && ShowTodayCircle && isToday && inMonth)
                 {
                     todayCircles.Add(new Rectangle(
-                        rect.X + (rect.Width - TodayCircleDiameter) / 2,
-                        rect.Y + (rect.Height - TodayCircleDiameter) / 2,
-                        TodayCircleDiameter,
-                        TodayCircleDiameter));
+                        rect.X + (rect.Width  - _todayCircleDiameter) / 2,
+                        rect.Y + (rect.Height - _todayCircleDiameter) / 2,
+                        _todayCircleDiameter,
+                        _todayCircleDiameter));
                 }
-
 
                 cx += _cellWidth;
             }
 
             gridY += _cellHeight;
         }
-        
-        using var todayPen = new Pen(TodayCircleColor, TodayCircleStroke);
-        foreach (var circle in todayCircles)
-        {
-            g.DrawEllipse(todayPen, circle);
-        }
 
+        using var todayPen = new Pen(TodayCircleColor, 1.8f);
+        foreach (var circle in todayCircles)
+            g.DrawEllipse(todayPen, circle);
     }
 
-    
-    // Paints a chevron glyph inside a rectangle (left/right).
+    // ── Chevron ───────────────────────────────────────────────────────────────
     private void DrawChevron(Graphics g, Rectangle rect, bool left)
     {
-        using var p = new Pen(SecondaryForeground, 1.2f);
-        var cx = rect.X + rect.Width / 2;
-        var cy = rect.Y + rect.Height / 2;
-        var size = Math.Max(4, rect.Height / 3);
+        using var p = new Pen(Color.FromArgb(0x3D, 0x3D, 0x3D), 2f);
+        int cx   = rect.X + rect.Width  / 2;
+        int cy   = rect.Y + rect.Height / 2;
+        int size = Math.Max(6, rect.Height / 2);
 
         g.DrawLines(p,
             left
-                ? new[] { new Point(cx + 2, cy - size), new Point(cx - 3, cy), new Point(cx + 2, cy + size) }
-                : new[] { new Point(cx - 2, cy - size), new Point(cx + 3, cy), new Point(cx - 2, cy + size) });
+                ? new[] { new Point(cx + 3, cy - size), new Point(cx - 4, cy), new Point(cx + 3, cy + size) }
+                : new[] { new Point(cx - 3, cy - size), new Point(cx + 4, cy), new Point(cx - 3, cy + size) });
     }
 
-    // Measures text to update minimum cell/row widths/heights.
+    // ── Metrics ───────────────────────────────────────────────────────────────
     private void ComputeMetrics(Graphics g)
     {
+        _headerVertPadding   = B_HeaderVertPadding;
+        _weekRowHeight       = B_WeekRowHeight;
+        _cellHeight          = B_CellHeight;
+        _cellWidth           = B_CellWidth;
+        _monthGap            = B_MonthGap;
+        _weekColumnWidth     = B_WeekColumnWidth;
+        _headerSidePadding   = B_HeaderSidePadding;
+        _footerHeight        = B_FooterHeight;
+        _footerSeparatorGap  = B_FooterSeparatorGap;
+        _gridBottomGap       = B_GridBottomGap;
+        _padLeft             = B_PadLeft;
+        _padTop              = B_PadTop;
+        _padRight            = B_PadRight;
+        _padBottom           = B_PadBottom;
+        _todayCircleDiameter = B_TodayCircleDiameter;
+        _footerBoxSize       = B_FooterBoxSize;
+
         var dtf = _culture.DateTimeFormat;
 
-        var longestDay = "Wed";
-        foreach (var s in dtf.AbbreviatedDayNames)
-            if (s.Length > longestDay.Length)
-                longestDay = s;
+        string longestDay = "Wed";
+        foreach (var abbr in dtf.AbbreviatedDayNames)
+            if (abbr.Length > longestDay.Length) longestDay = abbr;
 
-        var daySize = TextRenderer.MeasureText(g, longestDay, Font, new Size(int.MaxValue, int.MaxValue),
-            TextFormatFlags.NoPadding | TextFormatFlags.SingleLine);
-
-        var weekSize = TextRenderer.MeasureText(g, "53", Font, new Size(int.MaxValue, int.MaxValue),
-            TextFormatFlags.NoPadding | TextFormatFlags.SingleLine);
-
-        var titleProxy = TextRenderer.MeasureText(g, "September 2025", new Font(Font, FontStyle.Regular),
+        var daySize = TextRenderer.MeasureText(g, longestDay, Font,
             new Size(int.MaxValue, int.MaxValue),
             TextFormatFlags.NoPadding | TextFormatFlags.SingleLine);
 
-        _cellWidth = Math.Max(_cellWidth, daySize.Width + 8);
-        _weekColumnWidth = Math.Max(_weekColumnWidth, weekSize.Width + 10);
-        _weekRowHeight = Math.Max(_weekRowHeight, daySize.Height + 4);
-        _cellHeight = Math.Max(_cellHeight, daySize.Height + 8);
+        var weekSize = TextRenderer.MeasureText(g, "53", Font,
+            new Size(int.MaxValue, int.MaxValue),
+            TextFormatFlags.NoPadding | TextFormatFlags.SingleLine);
 
-        _headerHeight = titleProxy.Height + 2 * _headerVertPadding;
+        using var hf = new Font(Font, FontStyle.Bold);
+        var titleSize = TextRenderer.MeasureText(g, "September 2025", hf,
+            new Size(int.MaxValue, int.MaxValue),
+            TextFormatFlags.NoPadding | TextFormatFlags.SingleLine);
+
+        _cellWidth       = Math.Max(_cellWidth,       daySize.Width  + 8);
+        _weekColumnWidth = Math.Max(_weekColumnWidth,  weekSize.Width + 10);
+        _weekRowHeight   = Math.Max(_weekRowHeight,    daySize.Height + 4);
+        _cellHeight      = Math.Max(_cellHeight,       daySize.Height + 8);
+
+        _todayCircleDiameter = Math.Min(_todayCircleDiameter,
+            Math.Min(_cellWidth, _cellHeight) - 2);
+
+        _headerHeight = titleSize.Height + 2 * _headerVertPadding;
     }
 
-    // Handles mouse navigation and week-row hit testing.
+    private Size ComputeTotalSize()
+    {
+        int across = CalendarDimensions.Width;
+        int down   = CalendarDimensions.Height;
+
+        int weekColWidth = ShowWeekNumbers ? _weekColumnWidth : 0;
+        int monthWidth   = weekColWidth + _cellWidth * 7;
+        int mhFixed      = _headerHeight + _weekRowHeight + _cellHeight * FixedWeeksPerMonth;
+
+        int totalWidth  = _padLeft + across * monthWidth + (across - 1) * _monthGap + _padRight;
+        int totalHeight = _padTop  + down * mhFixed + (down - 1) * _monthGap
+                        + _gridBottomGap + 1 + _footerSeparatorGap + _footerHeight + _padBottom;
+
+        return new Size(totalWidth, totalHeight);
+    }
+
+    // ── Mouse ─────────────────────────────────────────────────────────────────
     protected override void OnMouseDown(MouseEventArgs e)
     {
-        if (_prevChevronRect.Contains(e.Location))
-        {
-            DisplayMonth = DisplayMonth.AddMonths(-1);
-            Invalidate();
-            return;
-        }
-
-        if (_nextChevronRect.Contains(e.Location))
-        {
-            DisplayMonth = DisplayMonth.AddMonths(1);
-            Invalidate();
-            return;
-        }
+        if (_prevChevronRect.Contains(e.Location)) { DisplayMonth = DisplayMonth.AddMonths(-1); Invalidate(); return; }
+        if (_nextChevronRect.Contains(e.Location)) { DisplayMonth = DisplayMonth.AddMonths(+1); Invalidate(); return; }
 
         if (_footerRect.Contains(e.Location))
         {
             var today = DateTime.Today;
             DisplayMonth = new DateTime(today.Year, today.Month, 1);
-            // Highlight today with ownership set to today's month to avoid duplicate highlight.
             HighlightIsoWeek(today, new DateTime(today.Year, today.Month, 1));
             Invalidate();
             return;
         }
 
-        var across = CalendarDimensions.Width;
-        var down = CalendarDimensions.Height;
+        int across = CalendarDimensions.Width;
+        int down   = CalendarDimensions.Height;
 
-        var weekColWidth = ShowWeekNumbers ? _weekColumnWidth : 0;
-        var monthWidth = weekColWidth + (_cellWidth * 7);
-        var monthHeightFixed = _headerHeight + _weekRowHeight + (_cellHeight * FixedWeeksPerMonth);
+        int weekColWidth = ShowWeekNumbers ? _weekColumnWidth : 0;
+        int monthWidth   = weekColWidth + _cellWidth * 7;
+        int mhFixed      = _headerHeight + _weekRowHeight + _cellHeight * FixedWeeksPerMonth;
 
         var monthCursor = DisplayMonth;
-        var yCursor = _padTop;
+        int yCursor     = _padTop;
 
-        for (var r = 0; r < down; r++)
+        for (int r = 0; r < down; r++)
         {
-            var xCursor = _padLeft;
-
-            for (var c = 0; c < across; c++)
+            int xCursor = _padLeft;
+            for (int c = 0; c < across; c++)
             {
-                var bounds = new Rectangle(xCursor, yCursor, monthWidth, monthHeightFixed);
+                var bounds = new Rectangle(xCursor, yCursor, monthWidth, mhFixed);
 
                 if (bounds.Contains(e.Location))
                 {
-                    var gridTop = bounds.Y + _headerHeight + _weekRowHeight;
-                    var yRel = e.Y - gridTop;
+                    int gridTop = bounds.Y + _headerHeight + _weekRowHeight;
+                    int yRel    = e.Y - gridTop;
 
                     if (yRel >= 0 && yRel < _cellHeight * FixedWeeksPerMonth)
                     {
-                        var row = yRel / _cellHeight;
-
+                        int row = yRel / _cellHeight;
                         var dtf = _culture.DateTimeFormat;
-                        DateTime firstOfMonth = new DateTime(monthCursor.Year, monthCursor.Month, 1);
-                        var offset = ((int)firstOfMonth.DayOfWeek - (int)dtf.FirstDayOfWeek + 7) % 7;
-                        DateTime gridStart = firstOfMonth.AddDays(-offset);
 
-                        // Set highlight week and explicitly assign ownership to the clicked month.
-                        var weekAnyDate = gridStart.AddDays(row * 7);
-                        _highlightWeekStart = StartOfIsoWeek(weekAnyDate);
-                        _highlightWeekMonth = firstOfMonth; // owning month = clicked month
+                        var firstOfMonth = new DateTime(monthCursor.Year, monthCursor.Month, 1);
+                        int offset       = ((int)firstOfMonth.DayOfWeek - (int)dtf.FirstDayOfWeek + 7) % 7;
+                        var gridStart    = firstOfMonth.AddDays(-offset);
+
+                        _highlightWeekStart = StartOfIsoWeek(gridStart.AddDays(row * 7));
+                        _highlightWeekMonth = firstOfMonth;
                         Invalidate();
                         return;
                     }
@@ -520,15 +517,14 @@ internal sealed class CalendarControl : Control
                 xCursor += monthWidth + (c < across - 1 ? _monthGap : 0);
                 monthCursor = monthCursor.AddMonths(1);
             }
-
-            yCursor += monthHeightFixed + (r < down - 1 ? _monthGap : 0);
+            yCursor += mhFixed + (r < down - 1 ? _monthGap : 0);
         }
     }
 
-    // Returns the Monday of the ISO week for a given date.
+    // ── Helpers ───────────────────────────────────────────────────────────────
     private static DateTime StartOfIsoWeek(DateTime date)
     {
-        var dow = (int)date.DayOfWeek;
+        int dow = (int)date.DayOfWeek;
         if (dow == 0) dow = 7;
         return date.AddDays(1 - dow).Date;
     }

--- a/WeekNumber/IconFactory.cs
+++ b/WeekNumber/IconFactory.cs
@@ -8,21 +8,25 @@ public class IconFactory : IIconFactory
     {
         using var bitmap = new Bitmap(iconSize, iconSize);
         using var graphics = Graphics.FromImage(bitmap);
-        graphics.TextRenderingHint = TextRenderingHint.AntiAliasGridFit;
-        graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
-        graphics.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
-        graphics.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.HighQuality;
         graphics.Clear(Color.Transparent);
 
         var text = number.ToString();
-        const int margin = -32;
-        using var adjustedFont = new Font(font.FontFamily, iconSize - 1, font.Style, GraphicsUnit.Pixel);
-        var size = graphics.MeasureString(text, adjustedFont);
+        using var adjustedFont = new Font(font.FontFamily, iconSize - 2, font.Style, GraphicsUnit.Pixel);
 
-        var x = Math.Max((iconSize - size.Width) / 2, margin);
-        var y = Math.Max((iconSize - size.Height) / 2, margin);
+        var size = TextRenderer.MeasureText(graphics, text, adjustedFont, new Size(iconSize, iconSize),
+            TextFormatFlags.NoPadding);
 
-        graphics.DrawString(text, adjustedFont, brush, x, y);
+        var x = (iconSize - size.Width) / 2;
+        var y = (iconSize - size.Height) / 2;
+
+        // Compensate for italic right-side overhang not captured by MeasureText
+        if (adjustedFont.Italic)
+            x -= (int)(size.Height * 0.1f);
+
+        var color = brush is SolidBrush sb ? sb.Color : Color.White;
+
+        TextRenderer.DrawText(graphics, text, adjustedFont, new Point(x, y), color,
+            TextFormatFlags.NoPadding);
 
         var handle = bitmap.GetHicon();
         return Icon.FromHandle(handle);

--- a/WeekNumber/NotificationAreaIcon.cs
+++ b/WeekNumber/NotificationAreaIcon.cs
@@ -19,9 +19,10 @@ public sealed class NotificationAreaIcon : IDisposable
     private Brush _currentBrush = BrushHelper.GetBrushFromColor(Properties.Settings.Default.SelectedColor);
     private const string DefaultFontFamily = "Arial";
     private Font _font = new(DefaultFontFamily, IconSizeInPixels, _currentFontStyle, GraphicsUnit.Pixel);
+    private ColorDialog? _colorDialog;
 
     public static NotificationAreaIcon Instance => _instance.Value;
-    
+
     internal NotificationAreaIcon(IIconFactory iconFactory)
     {
         _iconFactory = iconFactory;
@@ -34,19 +35,27 @@ public sealed class NotificationAreaIcon : IDisposable
         };
         var colorPickerMenuItem = new ToolStripMenuItem("Change Color", null, (_, _) =>
         {
-            using ColorDialog colorDialog = new();
-            colorDialog.AllowFullOpen = true;
-            colorDialog.AnyColor = true;
-            colorDialog.FullOpen = true;
-            colorDialog.CustomColors = [0xFF0000, 0x00FF00, 0x0000FF, 0xFFFF00, 0xFF00FF, 0x00FFFF];
-
-            if (colorDialog.ShowDialog() != DialogResult.OK)
+            if (_colorDialog != null)
                 return;
 
-            _currentBrush = BrushHelper.GetBrushFromColor(colorDialog.Color);
-            Properties.Settings.Default.SelectedColor = colorDialog.Color;
-            Properties.Settings.Default.Save();
-            UpdateIcon();
+            _colorDialog = new ColorDialog
+            {
+                AllowFullOpen = true,
+                AnyColor = true,
+                FullOpen = true,
+                CustomColors = [0xFF0000, 0x00FF00, 0x0000FF, 0xFFFF00, 0xFF00FF, 0x00FFFF]
+            };
+
+            if (_colorDialog.ShowDialog() == DialogResult.OK)
+            {
+                _currentBrush = BrushHelper.GetBrushFromColor(_colorDialog.Color);
+                Properties.Settings.Default.SelectedColor = _colorDialog.Color;
+                Properties.Settings.Default.Save();
+                UpdateIcon();
+            }
+
+            _colorDialog.Dispose();
+            _colorDialog = null;
         });
 
         var fontStyleMenuItem = new ToolStripMenuItem("Font Style");
@@ -104,6 +113,8 @@ public sealed class NotificationAreaIcon : IDisposable
         if (e.Button != MouseButtons.Left)
             return;
 
+        _contextMenu.Close();
+
         _weekNumber.UpdateNumber();
         UpdateIcon();
         UpdateText();
@@ -119,7 +130,6 @@ public sealed class NotificationAreaIcon : IDisposable
         StartupHelper.SetStartup(menuItem.Checked);
     }
 
-    
     private void OnPowerModeChanged(object? sender, PowerModeChangedEventArgs e)
     {
         if (e.Mode != PowerModes.Resume)
@@ -153,7 +163,7 @@ public sealed class NotificationAreaIcon : IDisposable
     }
 
     internal NotifyIcon NotifyIcon => _notifyIcon;
-    
+
     public void Dispose()
     {
         if (_disposed)
@@ -162,11 +172,9 @@ public sealed class NotificationAreaIcon : IDisposable
         _notifyIcon.Dispose();
         _disposed = true;
     }
-    
+
     public void MenuAbout_Click(object? sender, EventArgs e)
     {
-        // Show AboutForm as a dialog
-        using var about = new AboutForm();
-        about.ShowDialog();
+        AboutForm.ShowInstance();
     }
 }


### PR DESCRIPTION
The week number icon is better looking and in line with the other tray icons in the toolbar. Icon shifst a little bit to the left when italic mode is selected as fontstyle, because it was cutting off the second/right number of a weeknumber in the icon.

The about window has been updated to look more modern. Added that only one instance is allowed. The about window will open in the middle of the display. The popup is now display resolution independent.

The context menu list will now close when u leaft click on the icon. before the list would still be open in the back while the calendar would be displayed on top of the list.

the calendar gui colors changed a bit to highlight information better. The calendar gui is now display resolution independent.