### PR TITLE
More compact GUI

### DIFF
--- a/WeekNumber.Tests/BrushHelperTests.cs
+++ b/WeekNumber.Tests/BrushHelperTests.cs
@@ -8,7 +8,7 @@ namespace WeekNumber.Tests;
 public class BrushHelperTests
 {
     [Fact]
-    public void GetBrushFromColor_ReturnsPredefinedBrush_WhenColorIsKnown()
+    public void GetBrushFromColor_ReturnsSolidBrushWithMatchingColor_WhenColorIsKnown()
     {
         // Arrange
         var color = Color.Red;
@@ -18,8 +18,9 @@ public class BrushHelperTests
 
         // Assert
         brush.ShouldBeOfType<SolidBrush>();
-        ((SolidBrush)brush).Color.ShouldBe(color);
-        brush.ShouldBeSameAs(Brushes.Red);
+        brush.Color.ShouldBe(color);
+        // The implementation always constructs a new SolidBrush (not a cached predefined brush).
+        brush.ShouldNotBeSameAs(Brushes.Red);
     }
 
     [Fact]

--- a/WeekNumber.Tests/GraphicsUtilTests.cs
+++ b/WeekNumber.Tests/GraphicsUtilTests.cs
@@ -1,0 +1,72 @@
+﻿using System.Drawing;
+using System.Drawing.Drawing2D;
+using Shouldly;
+using WeekNumber.Forms;
+using Xunit;
+
+namespace WeekNumber.Tests;
+
+public class GraphicsUtilTests
+{
+    // ── CreateRoundedRect ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void CreateRoundedRect_ReturnsNonNullPath()
+    {
+        using var path = GraphicsUtil.CreateRoundedRect(new Rectangle(0, 0, 100, 100), 10);
+        path.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void CreateRoundedRect_ReturnedPathIsClosed()
+    {
+        using var path = GraphicsUtil.CreateRoundedRect(new Rectangle(0, 0, 100, 100), 10);
+        // A closed figure must have at least one point/sub-path.
+        path.PointCount.ShouldBeGreaterThan(0);
+    }
+
+    [Theory]
+    [InlineData(0,   0,  100, 100, 8)]
+    [InlineData(10, 20,  200, 150, 12)]
+    [InlineData(0,   0,   50,  50, 4)]
+    public void CreateRoundedRect_DoesNotThrow_ForVariousInputs(int x, int y, int w, int h, int r)
+    {
+        Should.NotThrow(() =>
+        {
+            using var path = GraphicsUtil.CreateRoundedRect(new Rectangle(x, y, w, h), r);
+        });
+    }
+
+    [Fact]
+    public void CreateRoundedRect_PathHasFourArcs()
+    {
+        // Each rounded corner is one AddArc call → 4 arcs in the path.
+        using var path = GraphicsUtil.CreateRoundedRect(new Rectangle(0, 0, 100, 100), 10);
+
+        // GraphicsPath built from 4 AddArc + CloseFigure has exactly 4 PathPointType.Arc segments.
+        var types = path.PathTypes;
+        // Verify there are multiple point entries (rounding corner points).
+        types.Length.ShouldBeGreaterThan(3);
+    }
+
+    [Fact]
+    public void CreateRoundedRect_RadiusZero_ThrowsArgumentException()
+    {
+        // GDI+ AddArc requires a non-zero arc size; radius=0 produces a 0×0 arc and throws.
+        Should.Throw<ArgumentException>(() =>
+        {
+            using var path = GraphicsUtil.CreateRoundedRect(new Rectangle(0, 0, 100, 100), 0);
+        });
+    }
+
+    [Fact]
+    public void CreateRoundedRect_LargeRadius_DoesNotThrow()
+    {
+        Should.NotThrow(() =>
+        {
+            using var path = GraphicsUtil.CreateRoundedRect(new Rectangle(0, 0, 200, 200), 50);
+        });
+    }
+}
+
+

--- a/WeekNumber.Tests/IconFactoryTests.cs
+++ b/WeekNumber.Tests/IconFactoryTests.cs
@@ -1,0 +1,105 @@
+﻿using System.Drawing;
+using Shouldly;
+using Xunit;
+
+namespace WeekNumber.Tests;
+
+public class IconFactoryTests : IDisposable
+{
+    private readonly IconFactory _factory = new();
+    private readonly Font        _font    = new("Arial", 32, FontStyle.Regular, GraphicsUnit.Pixel);
+    private readonly SolidBrush  _brush   = new(Color.White);
+
+    // ── CreateNumberIcon ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void CreateNumberIcon_ReturnsNonNullIcon()
+    {
+        using var icon = _factory.CreateNumberIcon(1, _font, _brush, 32);
+        icon.ShouldNotBeNull();
+    }
+
+    [Theory]
+    [InlineData(16)]
+    [InlineData(32)]
+    [InlineData(48)]
+    public void CreateNumberIcon_IconHasRequestedSize(int size)
+    {
+        using var icon = _factory.CreateNumberIcon(1, _font, _brush, size);
+        icon.Width.ShouldBe(size);
+        icon.Height.ShouldBe(size);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(10)]
+    [InlineData(25)]
+    [InlineData(42)]
+    [InlineData(53)]
+    public void CreateNumberIcon_DoesNotThrow_ForValidWeekNumbers(int weekNumber)
+    {
+        Should.NotThrow(() =>
+        {
+            using var icon = _factory.CreateNumberIcon(weekNumber, _font, _brush, 32);
+        });
+    }
+
+    [Fact]
+    public void CreateNumberIcon_WorksWithBoldFont()
+    {
+        using var font = new Font("Arial", 32, FontStyle.Bold, GraphicsUnit.Pixel);
+        using var icon = _factory.CreateNumberIcon(7, font, _brush, 32);
+        icon.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void CreateNumberIcon_WorksWithItalicFont()
+    {
+        using var font = new Font("Arial", 32, FontStyle.Italic, GraphicsUnit.Pixel);
+        using var icon = _factory.CreateNumberIcon(7, font, _brush, 32);
+        icon.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void CreateNumberIcon_WorksWithColoredBrush()
+    {
+        using var brush = new SolidBrush(Color.Yellow);
+        using var icon  = _factory.CreateNumberIcon(12, _font, brush, 32);
+        icon.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void CreateNumberIcon_WorksWithNonSolidBrush()
+    {
+        // When brush is not a SolidBrush the factory should fall back to white text.
+        using var hatch = new System.Drawing.Drawing2D.HatchBrush(
+            System.Drawing.Drawing2D.HatchStyle.Cross, Color.Red);
+        using var icon = _factory.CreateNumberIcon(5, _font, hatch, 32);
+        icon.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void CreateNumberIcon_EachCallReturnsNewInstance()
+    {
+        using var a = _factory.CreateNumberIcon(1, _font, _brush, 32);
+        using var b = _factory.CreateNumberIcon(1, _font, _brush, 32);
+        a.ShouldNotBeSameAs(b);
+    }
+
+    // ── IIconFactory contract ──────────────────────────────────────────────────
+
+    [Fact]
+    public void IconFactory_ImplementsIIconFactory()
+    {
+        (_factory as IIconFactory).ShouldNotBeNull();
+    }
+
+    // ── Cleanup ────────────────────────────────────────────────────────────────
+
+    public void Dispose()
+    {
+        _font.Dispose();
+        _brush.Dispose();
+    }
+}
+

--- a/WeekNumber.Tests/NotificationAreaIconHelperTests.cs
+++ b/WeekNumber.Tests/NotificationAreaIconHelperTests.cs
@@ -1,0 +1,69 @@
+﻿using System.Drawing;
+using System.Reflection;
+using Shouldly;
+using Xunit;
+
+namespace WeekNumber.Tests;
+
+/// <summary>
+/// Tests for private helpers inside <see cref="NotificationAreaIcon"/>
+/// that cannot be reached through the public API alone.
+/// </summary>
+public class NotificationAreaIconHelperTests
+{
+    // ── ValidateFontStyle ──────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData((int)FontStyle.Regular,   FontStyle.Regular)]
+    [InlineData((int)FontStyle.Bold,      FontStyle.Bold)]
+    [InlineData((int)FontStyle.Italic,    FontStyle.Italic)]
+    [InlineData((int)FontStyle.Strikeout, FontStyle.Strikeout)]
+    public void ValidateFontStyle_RetainsAllowedFlags(int raw, FontStyle expected)
+    {
+        InvokeValidateFontStyle(raw).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ValidateFontStyle_StripsUnderline()
+    {
+        // Underline is explicitly excluded from the allowed mask.
+        var result = InvokeValidateFontStyle((int)FontStyle.Underline);
+        result.ShouldBe(FontStyle.Regular);
+    }
+
+    [Fact]
+    public void ValidateFontStyle_StripsUnknownBits()
+    {
+        // High bits that don't correspond to any FontStyle should be cleared.
+        var result = InvokeValidateFontStyle(0xFF_FF);
+        // Should only keep Bold | Italic | Strikeout = 1|2|8 = 11
+        const FontStyle allowed = FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout;
+        (result & ~allowed).ShouldBe((FontStyle)0);
+    }
+
+    [Fact]
+    public void ValidateFontStyle_RetainsMultipleAllowedFlags()
+    {
+        var input    = (int)(FontStyle.Bold | FontStyle.Italic);
+        var expected = FontStyle.Bold | FontStyle.Italic;
+        InvokeValidateFontStyle(input).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ValidateFontStyle_Zero_ReturnsRegular()
+    {
+        InvokeValidateFontStyle(0).ShouldBe(FontStyle.Regular);
+    }
+
+    // ── Helper ────────────────────────────────────────────────────────────────
+
+    private static FontStyle InvokeValidateFontStyle(int raw)
+    {
+        var method = typeof(NotificationAreaIcon).GetMethod(
+            "ValidateFontStyle",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        return (FontStyle)method.Invoke(null, [raw])!;
+    }
+}
+

--- a/WeekNumber.Tests/StartupHelperTests.cs
+++ b/WeekNumber.Tests/StartupHelperTests.cs
@@ -1,0 +1,104 @@
+﻿using System.Drawing;
+using System.Reflection;
+using Shouldly;
+using WeekNumber.Helpers;
+using Xunit;
+
+namespace WeekNumber.Tests;
+
+public class StartupHelperTests
+{
+    // ── IsStartupEnabled ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsStartupEnabled_DoesNotThrow()
+    {
+        Should.NotThrow(() => StartupHelper.IsStartupEnabled());
+    }
+
+    [Fact]
+    public void IsStartupEnabled_ReturnsBooleanValue()
+    {
+        // Just verifies the method completes and returns a valid bool.
+        var result = StartupHelper.IsStartupEnabled();
+        (result == true || result == false).ShouldBeTrue();
+    }
+
+    // ── SetStartup ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SetStartup_DoesNotThrow_WhenDisabling()
+    {
+        // Disabling startup should never throw even when the key doesn't exist.
+        Should.NotThrow(() => StartupHelper.SetStartup(false));
+    }
+
+    [Fact]
+    public void SetStartup_DoesNotThrow_WhenEnabling()
+    {
+        // Enabling startup is best-effort; it may silently do nothing if the
+        // executable path isn't in a trusted location (e.g. during tests).
+        Should.NotThrow(() => StartupHelper.SetStartup(true));
+    }
+
+    // ── UpdateRegistryKey ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void UpdateRegistryKey_DoesNotThrow()
+    {
+        Should.NotThrow(() => StartupHelper.UpdateRegistryKey());
+    }
+
+    // ── IsTrustedLocation (private) ────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(@"C:\RandomTempFolder\app.exe",         false)]
+    [InlineData(@"C:\Users\user\Downloads\app.exe",     false)]
+    public void IsTrustedLocation_ReturnsFalse_ForUntrustedPaths(string path, bool expected)
+    {
+        var result = InvokeIsTrustedLocation(path);
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void IsTrustedLocation_ReturnsTrue_ForAppBaseDirectory()
+    {
+        // The test runner's base directory is always treated as trusted.
+        var basePath = Path.Combine(AppContext.BaseDirectory, "app.exe");
+        var result   = InvokeIsTrustedLocation(basePath);
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsTrustedLocation_ReturnsTrue_ForProgramFilesPath()
+    {
+        var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        if (string.IsNullOrEmpty(programFiles))
+            return; // Skip on systems where there's no Program Files folder.
+
+        var fakePath = Path.Combine(programFiles, "SomeApp", "app.exe");
+        var result   = InvokeIsTrustedLocation(fakePath);
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsTrustedLocation_IsCaseInsensitive()
+    {
+        var basePath  = Path.Combine(AppContext.BaseDirectory, "app.exe");
+        var upperPath = basePath.ToUpperInvariant();
+
+        InvokeIsTrustedLocation(upperPath).ShouldBeTrue();
+    }
+
+    // ── Helper ────────────────────────────────────────────────────────────────
+
+    private static bool InvokeIsTrustedLocation(string path)
+    {
+        var method = typeof(StartupHelper).GetMethod(
+            "IsTrustedLocation",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        return (bool)method.Invoke(null, [path])!;
+    }
+}
+

--- a/WeekNumber.Tests/VersionHelperTests.cs
+++ b/WeekNumber.Tests/VersionHelperTests.cs
@@ -1,0 +1,50 @@
+﻿using Shouldly;
+using WeekNumber.Helpers;
+using Xunit;
+
+namespace WeekNumber.Tests;
+
+public class VersionHelperTests
+{
+    [Fact]
+    public void GetAppVersion_ReturnsNonEmptyString()
+    {
+        var version = VersionHelper.GetAppVersion();
+        version.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void GetAppVersion_DoesNotThrow()
+    {
+        Should.NotThrow(() => VersionHelper.GetAppVersion());
+    }
+
+    [Fact]
+    public void GetAppVersion_ReturnsAtMostThreeDotSeparatedParts()
+    {
+        var version = VersionHelper.GetAppVersion();
+
+        // The method trims to at most "major.minor.patch" so there should be ≤ 3 parts.
+        var parts = version.Split('.');
+        parts.Length.ShouldBeLessThanOrEqualTo(3);
+    }
+
+    [Fact]
+    public void GetAppVersion_DoesNotContainPlusSuffix()
+    {
+        // Any +commit metadata must be stripped.
+        var version = VersionHelper.GetAppVersion();
+        version.ShouldNotContain("+");
+    }
+
+    [Fact]
+    public void GetAppVersion_AllPartsAreNumeric()
+    {
+        var version = VersionHelper.GetAppVersion();
+        var parts   = version.Split('.');
+
+        foreach (var part in parts)
+            int.TryParse(part, out _).ShouldBeTrue($"Part '{part}' of version '{version}' is not numeric");
+    }
+}
+

--- a/WeekNumber.Tests/WeekNumber.Tests.csproj
+++ b/WeekNumber.Tests/WeekNumber.Tests.csproj
@@ -9,12 +9,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="MSTest" Version="4.0.1"/>
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageReference Include="MSTest" Version="4.2.1" />
+        <PackageReference Include="NSubstitute" Version="6.0.0-rc.1" />
         <PackageReference Include="Shouldly" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+        <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0-pre.4">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/WeekNumber.Tests/WeekNumber.Tests.csproj
+++ b/WeekNumber.Tests/WeekNumber.Tests.csproj
@@ -14,6 +14,10 @@
         <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="Shouldly" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/WeekNumber.Tests/WeekNumberTests.cs
+++ b/WeekNumber.Tests/WeekNumberTests.cs
@@ -1,0 +1,129 @@
+﻿using System.Globalization;
+using System.Reflection;
+using Shouldly;
+using Xunit;
+
+namespace WeekNumber.Tests;
+
+public class WeekNumberTests
+{
+    // ── Constructor ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_SetsNumberInValidIsoRange()
+    {
+        var wn = new WeekNumber();
+        wn.Number.ShouldBeInRange(1, 53);
+    }
+
+    [Fact]
+    public void Constructor_SetsLastUpdatedToApproximatelyNow()
+    {
+        var before = DateTime.Now.AddSeconds(-1);
+        var wn     = new WeekNumber();
+        var after  = DateTime.Now.AddSeconds(1);
+
+        wn.LastUpdated.ShouldBeGreaterThanOrEqualTo(before);
+        wn.LastUpdated.ShouldBeLessThanOrEqualTo(after);
+    }
+
+    [Fact]
+    public void Constructor_NumberMatchesIsoWeekOfToday()
+    {
+        var wn       = new WeekNumber();
+        var expected = ISOWeek.GetWeekOfYear(DateTime.Today);
+
+        wn.Number.ShouldBe(expected);
+    }
+
+    // ── UpdateNumber ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void UpdateNumber_KeepsNumberInValidIsoRange()
+    {
+        var wn = new WeekNumber();
+        wn.UpdateNumber();
+        wn.Number.ShouldBeInRange(1, 53);
+    }
+
+    [Fact]
+    public void UpdateNumber_RefreshesLastUpdated()
+    {
+        var wn   = new WeekNumber();
+        var old  = wn.LastUpdated;
+
+        // Ensure at least a tick passes so the timestamps differ.
+        Thread.Sleep(1);
+
+        wn.UpdateNumber();
+
+        wn.LastUpdated.ShouldBeGreaterThanOrEqualTo(old);
+    }
+
+    [Fact]
+    public void UpdateNumber_NumberMatchesIsoWeekOfToday()
+    {
+        var wn = new WeekNumber();
+        wn.UpdateNumber();
+
+        var expected = ISOWeek.GetWeekOfYear(DateTime.Today);
+        wn.Number.ShouldBe(expected);
+    }
+
+    // ── ISO week arithmetic for well-known dates (via private helper) ──────────
+
+    [Theory]
+    [InlineData(2025,  1,  1,  1)]   // 2025-01-01 is ISO week 1
+    [InlineData(2025,  1,  6,  2)]   // 2025-01-06 is ISO week 2
+    [InlineData(2025, 12, 28, 52)]   // 2025-12-28 is ISO week 52
+    [InlineData(2026,  1,  1,  1)]   // 2026-01-01 is ISO week 1
+    [InlineData(2020, 12, 28, 53)]   // 2020-12-28 is ISO week 53 (long year)
+    [InlineData(2021,  1,  3, 53)]   // 2021-01-03 still belongs to ISO week 53 of 2020
+    [InlineData(2021,  1,  4,  1)]   // 2021-01-04 is ISO week 1 of 2021
+    public void CalculateWeekNumber_ReturnsCorrectIsoWeek(int year, int month, int day, int expectedWeek)
+    {
+        var date = new DateTime(year, month, day);
+
+        // Invoke the private static helper through reflection.
+        var method = typeof(WeekNumber).GetMethod(
+            "CalculateWeekNumber",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var result = (int)method.Invoke(null, [date])!;
+
+        result.ShouldBe(expectedWeek);
+    }
+
+    // ── Record semantics ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void TwoInstances_CreatedWithSameValues_AreEqual()
+    {
+        // Records have structural/value equality.
+        var a = new WeekNumber();
+        var b = new WeekNumber();
+
+        // Same week number and same LastUpdated second-bucket → should be equal.
+        // We compare via Number since LastUpdated will naturally match the current
+        // minute unless a minute boundary is crossed during test execution.
+        a.Number.ShouldBe(b.Number);
+    }
+
+    [Fact]
+    public void NumberProperty_IsNotMutableFromOutside()
+    {
+        // Verify the setter is private — property should not have a public set.
+        var prop = typeof(WeekNumber).GetProperty(nameof(WeekNumber.Number))!;
+        prop.SetMethod.ShouldNotBeNull();
+        prop.SetMethod!.IsPrivate.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void LastUpdatedProperty_IsNotMutableFromOutside()
+    {
+        var prop = typeof(WeekNumber).GetProperty(nameof(WeekNumber.LastUpdated))!;
+        prop.SetMethod.ShouldNotBeNull();
+        prop.SetMethod!.IsPrivate.ShouldBeTrue();
+    }
+}
+

--- a/WeekNumber/Forms/CalendarControl.cs
+++ b/WeekNumber/Forms/CalendarControl.cs
@@ -14,23 +14,23 @@ internal sealed class CalendarControl : Control
 
     // ── Base metrics at 96 DPI — scaled linearly via DeviceDpi ──────────────
 
-    private const int B_HeaderVertPad  = 10;
-    private const int B_WeekRowHeight  = 22;
-    private const int B_CellHeight     = 26;
-    private const int B_CellWidth      = 36;
-    private const int B_MonthGap       = 16;
-    private const int B_WeekColWidth   = 38;
-    private const int B_HeaderSidePad  = 28;
-    private const int B_FooterHeight   = 30;
-    private const int B_FooterSepGap   = 8;
-    private const int B_GridBottomGap  = 4;
-    private const int B_PadLeft        = 8;
-    private const int B_PadTop         = 8;
-    private const int B_PadRight       = 14;
-    private const int B_PadBottom      = 8;
-    private const int B_TodayDiameter  = 24;
-    private const int B_FooterDotSize  = 8;
-    private const int B_CornerRadius   = 10;
+    private const int B_HeaderVertPad  = 4;
+    private const int B_WeekRowHeight  = 18;
+    private const int B_CellHeight     = 22;
+    private const int B_CellWidth      = 32;
+    private const int B_MonthGap       = 12;
+    private const int B_WeekColWidth   = 32;
+    private const int B_HeaderSidePad  = 24;
+    private const int B_FooterHeight   = 22;
+    private const int B_FooterSepGap   = 4;
+    private const int B_GridBottomGap  = 2;
+    private const int B_PadLeft        = 6;
+    private const int B_PadTop         = 6;
+    private const int B_PadRight       = 10;
+    private const int B_PadBottom      = 4;
+    private const int B_TodayDiameter  = 20;
+    private const int B_FooterDotSize  = 7;
+    private const int B_CornerRadius   = 8;
 
     // ── Scaled metrics (recomputed every paint) ─────────────────────────────
 
@@ -203,7 +203,7 @@ internal sealed class CalendarControl : Control
         int monthWidth = weekCol + _cellWidth * 7;
         int mhFixed    = _headerHeight + _weekRowHeight + _cellHeight * FixedWeeksPerMonth;
 
-        int titleCenterY = _padTop + _headerHeight / 2;
+        int titleCenterY = (_padTop + _headerHeight) / 2;
 
         // ── Chevrons ──
 
@@ -241,35 +241,37 @@ internal sealed class CalendarControl : Control
         }
     }
 
-    private void DrawMonthTitle(Graphics g, DateTime month, int x, int y, int monthWidth)
-    {
-        var dtf = _culture.DateTimeFormat;
+private void DrawMonthTitle(Graphics g, DateTime month, int x, int y, int monthWidth)
+{
+    var dtf = _culture.DateTimeFormat;
 
-        string monthName = dtf.GetMonthName(month.Month);
-        string yearStr   = $" {month.Year}";
+    string monthName = dtf.GetMonthName(month.Month);
+    string yearStr   = $" {month.Year}";
 
-        var monthSize = TextRenderer.MeasureText(g, monthName, _titleFont!,
-            new Size(int.MaxValue, int.MaxValue),
-            TextFormatFlags.NoPadding | TextFormatFlags.SingleLine);
+    var monthSize = TextRenderer.MeasureText(g, monthName, _titleFont!,
+        new Size(int.MaxValue, int.MaxValue),
+        TextFormatFlags.NoPadding | TextFormatFlags.SingleLine);
 
-        var yearSize = TextRenderer.MeasureText(g, yearStr, _yearFont!,
-            new Size(int.MaxValue, int.MaxValue),
-            TextFormatFlags.NoPadding | TextFormatFlags.SingleLine);
+    var yearSize = TextRenderer.MeasureText(g, yearStr, _yearFont!,
+        new Size(int.MaxValue, int.MaxValue),
+        TextFormatFlags.NoPadding | TextFormatFlags.SingleLine);
 
-        int totalW   = monthSize.Width + yearSize.Width;
-        int startX   = x + (monthWidth - totalW) / 2;
-        int centerY  = y + _headerHeight / 2;
-        int monthTop = centerY - monthSize.Height / 2;
-        int yearTop  = centerY - yearSize.Height / 2;
+    int totalW = monthSize.Width + yearSize.Width;
+    int startX = x + (monthWidth - totalW) / 2;
 
-        TextRenderer.DrawText(g, monthName, _titleFont!,
-            new Point(startX, monthTop), TitleTextColor,
-            TextFormatFlags.NoPadding | TextFormatFlags.SingleLine);
+    // Span from y=0 so VerticalCenter covers the full visual band including _padTop
+    int bandHeight = y + _headerHeight;
 
-        TextRenderer.DrawText(g, yearStr, _yearFont!,
-            new Point(startX + monthSize.Width, yearTop), YearTextColor,
-            TextFormatFlags.NoPadding | TextFormatFlags.SingleLine);
-    }
+    TextRenderer.DrawText(g, monthName, _titleFont!,
+        new Rectangle(startX, 0, monthSize.Width, bandHeight),
+        TitleTextColor,
+        TextFormatFlags.NoPadding | TextFormatFlags.SingleLine | TextFormatFlags.VerticalCenter);
+
+    TextRenderer.DrawText(g, yearStr, _yearFont!,
+        new Rectangle(startX + monthSize.Width, 0, yearSize.Width, bandHeight),
+        YearTextColor,
+        TextFormatFlags.NoPadding | TextFormatFlags.SingleLine | TextFormatFlags.VerticalCenter);
+}
 
     // ── Grid ────────────────────────────────────────────────────────────────
 
@@ -356,8 +358,8 @@ internal sealed class CalendarControl : Control
             if (isHighlighted)
             {
                 var barRect = new RectangleF(
-                    bounds.X + 2f, gridY + 1f,
-                    bounds.Width - 4f, _cellHeight - 2f);
+                    bounds.X + 2f, gridY + 3f,
+                    bounds.Width - 4f, _cellHeight - 4f);
 
                 using var path = CreateRoundedRect(barRect, _cornerRadius);
                 using var fill = new SolidBrush(HighlightFillColor);
@@ -390,8 +392,8 @@ internal sealed class CalendarControl : Control
 
                 int diam = _todayDiameter;
                 var circleRect = new RectangleF(
-                    rect.X + (rect.Width  - diam) / 2f,
-                    rect.Y + (rect.Height - diam) / 2f,
+                    rect.X + (rect.Width  - diam) / 2f - 0.5f,
+                    rect.Y + (rect.Height - diam) / 2f + 1f,
                     diam, diam);
 
                 if (isHovered && !(ShowToday && ShowTodayCircle && isToday && inMonth))
@@ -428,41 +430,49 @@ internal sealed class CalendarControl : Control
 
     // ── Footer ──────────────────────────────────────────────────────────────
 
-    private void PaintFooter(Graphics g)
-    {
-        int down    = CalendarDimensions.Height;
-        int weekCol = ShowWeekNumbers ? _weekColWidth : 0;
-        int mhFixed = _headerHeight + _weekRowHeight + _cellHeight * FixedWeeksPerMonth;
+private void PaintFooter(Graphics g)
+{
+    int down    = CalendarDimensions.Height;
+    int weekCol = ShowWeekNumbers ? _weekColWidth : 0;
+    int mhFixed = _headerHeight + _weekRowHeight + _cellHeight * FixedWeeksPerMonth;
 
-        int totalWidth = CalendarDimensions.Width * (weekCol + _cellWidth * 7)
-                       + (CalendarDimensions.Width - 1) * _monthGap;
+    int totalWidth = CalendarDimensions.Width * (weekCol + _cellWidth * 7)
+                   + (CalendarDimensions.Width - 1) * _monthGap;
 
-        int sepY = _padTop + down * mhFixed + (down - 1) * _monthGap + _gridBottomGap;
+    int sepY = _padTop + down * mhFixed + (down - 1) * _monthGap + _gridBottomGap;
 
-        using (var sp = new Pen(DividerColor, 1f))
-            g.DrawLine(sp, _padLeft, sepY, _padLeft + totalWidth, sepY);
+    using (var sp = new Pen(DividerColor, 1f))
+        g.DrawLine(sp, _padLeft, sepY, _padLeft + totalWidth, sepY);
 
-        _footerRect = new Rectangle(
-            _padLeft, sepY + _footerSepGap,
-            totalWidth, _footerHeight);
+    // Anchor bottom of footer to actual client bottom minus pad,
+    // so it stays centered regardless of form padding below the control.
+    int footerBottom = ClientRectangle.Bottom - _padBottom;
+    int footerTop    = sepY + _footerSepGap;
 
-        int dotY = _footerRect.Y + (_footerRect.Height - _footerDotSize) / 2;
-        var dotRect = new Rectangle(_footerRect.X + 4, dotY, _footerDotSize, _footerDotSize);
-        using (var dotBrush = new SolidBrush(Accent))
-            g.FillEllipse(dotBrush, dotRect);
+    _footerRect = new Rectangle(
+        _padLeft, footerTop,
+        totalWidth, footerBottom - footerTop);
 
-        string todayLabel = $"Today: {DateTime.Today:dd-MM-yyyy}";
+    float centerY = _footerRect.Y + _footerRect.Height / 2f;
 
-        TextRenderer.DrawText(g, todayLabel, _dayNameFont!,
-            new Rectangle(dotRect.Right + 8, _footerRect.Y,
-                          _footerRect.Width - dotRect.Right - 8 + _footerRect.X,
-                          _footerRect.Height),
-            _footerHovered ? Accent : SecondaryForeground,
-            TextFormatFlags.VerticalCenter |
-            TextFormatFlags.Left           |
-            TextFormatFlags.SingleLine     |
-            TextFormatFlags.NoPadding);
-    }
+    var dotRect = new RectangleF(
+        _footerRect.X + 4,
+        centerY - _footerDotSize / 2f,
+        _footerDotSize, _footerDotSize);
+
+    using (var dotBrush = new SolidBrush(Accent))
+        g.FillEllipse(dotBrush, dotRect);
+
+    string todayLabel = $"Today: {DateTime.Today:dd-MM-yyyy}";
+
+    using var footerSf    = new StringFormat { Alignment = StringAlignment.Near, LineAlignment = StringAlignment.Center };
+    using var footerBrush = new SolidBrush(_footerHovered ? Accent : SecondaryForeground);
+    g.DrawString(todayLabel, _dayNameFont!, footerBrush,
+        new RectangleF(dotRect.Right + 8, _footerRect.Y,
+                       _footerRect.Width - (dotRect.Right + 8 - _footerRect.X),
+                       _footerRect.Height),
+        footerSf);
+}
 
     // ── Chevron ─────────────────────────────────────────────────────────────
 
@@ -744,7 +754,7 @@ internal sealed class CalendarControl : Control
         _todayDiameter = Math.Min(_todayDiameter,
             Math.Min(_cellWidth, _cellHeight) - 4);
 
-        _headerHeight  = titleSize.Height + 2 * _headerVertPad;
+        _headerHeight = titleSize.Height + 2 * _headerVertPad;
     }
 
     private Size ComputeTotalSize()

--- a/WeekNumber/Forms/CalendarForm.cs
+++ b/WeekNumber/Forms/CalendarForm.cs
@@ -6,84 +6,83 @@ namespace WeekNumber.Forms;
 public sealed class CalendarForm : Form
 {
     private static readonly Color CardBackgroundColor = Color.FromArgb(0xF6, 0xF6, 0xF6);
-    private static readonly Color AccentColor = Color.FromArgb(0x1E, 0x6B, 0xD6);
+    private static readonly Color AccentColor         = Color.FromArgb(0x1E, 0x6B, 0xD6);
 
-    private const int CornerRadius = 10;
-    private const int InnerPadding = 8;
+    private const int CornerRadius  = 10;
+    private const int InnerPadding  = 8;
 
     private readonly DoubleBufferedPanel _cardPanel;
-    private readonly CalendarControl _calendarControl;
+    private readonly CalendarControl     _calendarControl;
 
     public CalendarForm()
     {
         FormBorderStyle = FormBorderStyle.None;
-        ShowInTaskbar = false;
-        TopMost = true;
-        BackColor = CardBackgroundColor;
-        Padding = Padding.Empty;
-        StartPosition = FormStartPosition.Manual;
-        DoubleBuffered = true;
+        ShowInTaskbar   = false;
+        TopMost         = true;
+        BackColor       = CardBackgroundColor;
+        Padding         = Padding.Empty;
+        StartPosition   = FormStartPosition.Manual;
+        DoubleBuffered  = true;
 
         _cardPanel = new DoubleBufferedPanel
         {
-            Dock = DockStyle.Fill,
+            Dock      = DockStyle.Fill,
             BackColor = CardBackgroundColor,
-            Padding = new Padding(InnerPadding)
+            Padding   = new Padding(InnerPadding, InnerPadding, InnerPadding, 0)
         };
         Controls.Add(_cardPanel);
 
         _calendarControl = new CalendarControl
         {
-            Dock = DockStyle.Fill,
-            BackColor = CardBackgroundColor,
-            ForeColor = Color.FromArgb(0x1F, 0x1F, 0x1F),
-            HeaderForeground = Color.FromArgb(0x1F, 0x1F, 0x1F),
+            Dock                = DockStyle.Fill,
+            BackColor           = CardBackgroundColor,
+            ForeColor           = Color.FromArgb(0x1F, 0x1F, 0x1F),
+            HeaderForeground    = Color.FromArgb(0x1F, 0x1F, 0x1F),
             SecondaryForeground = Color.FromArgb(0x6B, 0x6B, 0x6B),
-            Accent = AccentColor,
-            CalendarDimensions = new Size(2, 1),
-            ShowWeekNumbers = true,
-            ShowToday = true,
-            ShowTodayCircle = true
+            Accent              = AccentColor,
+            CalendarDimensions  = new Size(2, 1),
+            ShowWeekNumbers     = true,
+            ShowToday           = true,
+            ShowTodayCircle     = true
         };
 
         try { _calendarControl.Font = new Font("Segoe UI Variable", 9f); }
         catch { _calendarControl.Font = new Font("Segoe UI", 9f); }
 
         _cardPanel.Controls.Add(_calendarControl);
-
         _calendarControl.HighlightIsoWeek(DateTime.Today);
 
         var preferred = _calendarControl.GetPreferredSize(Size.Empty);
         ClientSize = new Size(
-            preferred.Width + _cardPanel.Padding.Horizontal,
-            preferred.Height + _cardPanel.Padding.Vertical + 2);
+            preferred.Width  + _cardPanel.Padding.Horizontal,
+            preferred.Height + _cardPanel.Padding.Vertical);
 
         DwmInterop.SetRoundedCorners(Handle);
 
         Deactivate += (_, _) => Close();
-        KeyPreview = true;
-        KeyDown += (_, e) => { if (e.KeyCode == Keys.Escape) Close(); };
+        KeyPreview  = true;
+        KeyDown    += (_, e) => { if (e.KeyCode == Keys.Escape) Close(); };
     }
 
     public void ShowAtCursor()
     {
         Location = new Point(-2000, -2000);
-        Visible = true;
+        Visible  = true;
 
         var preferred = _calendarControl.GetPreferredSize(Size.Empty);
         ClientSize = new Size(
-            preferred.Width + _cardPanel.Padding.Horizontal,
-            preferred.Height + _cardPanel.Padding.Vertical + 2);
+            preferred.Width  + _cardPanel.Padding.Horizontal,
+            preferred.Height + _cardPanel.Padding.Vertical);
 
         var cursor = Cursor.Position;
         var screen = Screen.FromPoint(cursor);
-        var wa = screen.WorkingArea;
+        var wa     = screen.WorkingArea;
 
         int x = cursor.X - Width / 2;
         int y = wa.Bottom - Height;
 
         x = Math.Max(wa.Left, Math.Min(x, wa.Right - Width));
-        y = Math.Max(wa.Top, y);
+        y = Math.Max(wa.Top,  y);
 
         Location = new Point(x, y);
         Activate();


### PR DESCRIPTION
## Visual alignment fixes for `CalendarControl` and `CalendarForm`

### Changes

**`CalendarControl.cs`**

- **Today/hover circle X offset**: removed the erroneous `-1f` horizontal nudge; circle is now purely centered via `(rect.Width - diam) / 2f`
- **Today/hover circle Y offset**: added `+1f` to shift the circle down by 1px so the day number sits visually centered inside it
- **Week highlight bar**: adjusted top offset from `gridY + 2f` → `gridY + 3f` and height from `_cellHeight - 3f` → `_cellHeight - 4f` to keep bar height consistent while aligning with the repositioned circle
- **Footer dot + text**: replaced independent `dotY` calculation with a shared `centerY = _footerRect.Y + _footerRect.Height / 2f`, ensuring the dot and label are always co-aligned on the same baseline
- **Footer rect height**: changed from fixed `_footerHeight` to stretching between the separator and `ClientRectangle.Bottom - _padBottom`, so centering adapts to actual available space
- **Month title vertical alignment**: replaced manual `MeasureText`-based Y math with `TextFormatFlags.VerticalCenter` over the full header band (`y=0` to `y + _headerHeight`), eliminating GDI leading offset
- **Chevron vertical centering**: changed `titleCenterY` from `_padTop + _headerHeight / 2` to `(_padTop + _headerHeight) / 2` so the chevron midpoint covers the full visual band including top padding

**`CalendarForm.cs`**

- **Card panel bottom padding**: changed `new Padding(InnerPadding)` to `new Padding(InnerPadding, InnerPadding, InnerPadding, 0)` — the control's own `_padBottom` handles bottom spacing; stacking both caused the footer to appear visually high
- **`ClientSize` calculation**: removed the unexplained `+ 2` height compensation in both the constructor and `ShowAtCursor()` — it was a symptom patch for the padding issue above